### PR TITLE
fix next size

### DIFF
--- a/32bit/malloc.c
+++ b/32bit/malloc.c
@@ -76,7 +76,7 @@ void* malloc(unsigned size)
 			next->prev	= header;
 			next->next	= header->next;
 			next->type	= HEAP_BLOCK_FREE;
-			next->size	= header->size -(size - HEADER_SIZE);
+			next->size	= header->size -(size + HEADER_SIZE);
 			header->next	= next;
 			header->size	= size +HEADER_SIZE;
 			header->type	= HEAP_BLOCK_USED;

--- a/64bit/malloc.c
+++ b/64bit/malloc.c
@@ -75,7 +75,7 @@ void* malloc(unsigned long size)
 			next->prev	= header;
 			next->next	= header->next;
 			next->type	= HEAP_BLOCK_FREE;
-			next->size	= header->size -(size - HEADER_SIZE);
+			next->size	= header->size -(size + HEADER_SIZE);
 			header->next	= next;
 			header->size	= size +HEADER_SIZE;
 			header->type	= HEAP_BLOCK_USED;


### PR DESCRIPTION
hi,i find that  void* malloc(unsigned size) in malloc.c has a bug.

when we malloc,the memory layout like this: header1,size1,header2,size2.
header will take up space and header->size includes header. 
header1->size > size1
 
so,next->size	= header->size -(size + HEADER_SIZE);